### PR TITLE
Add broadcast/subscribe websockets to message dispatching

### DIFF
--- a/lib/live_view_chat/chat.ex
+++ b/lib/live_view_chat/chat.ex
@@ -17,9 +17,7 @@ defmodule LiveViewChat.Chat do
       [%Message{}, ...]
 
   """
-  def list_messages do
-    Repo.all(Message)
-  end
+  def list_messages, do: Repo.all(Message)
 
   @doc """
   Gets a single message.
@@ -53,6 +51,7 @@ defmodule LiveViewChat.Chat do
     %Message{}
     |> Message.changeset(attrs)
     |> Repo.insert()
+    |> broadcast(:message_created)
   end
 
   @doc """
@@ -100,5 +99,15 @@ defmodule LiveViewChat.Chat do
   """
   def change_message(%Message{} = message, attrs \\ %{}) do
     Message.changeset(message, attrs)
+  end
+
+  def subscribe() do
+    Phoenix.PubSub.subscribe(LiveViewChat.PubSub, "messages")
+  end
+
+  defp broadcast({:error, _reason} = error, _event), do: error
+  defp broadcast({:ok, message}, event) do
+    Phoenix.PubSub.broadcast(LiveViewChat.PubSub, "messages", {event, message})
+    {:ok, message}
   end
 end

--- a/lib/live_view_chat_web/live/message_live/index.ex
+++ b/lib/live_view_chat_web/live/message_live/index.ex
@@ -6,6 +6,8 @@ defmodule LiveViewChatWeb.MessageLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
+    if connected?(socket), do: Chat.subscribe()
+
     {:ok, assign(socket, :messages, list_messages())}
   end
 
@@ -45,6 +47,11 @@ defmodule LiveViewChatWeb.MessageLive.Index do
     {:ok, _} = Chat.delete_message(message)
 
     {:noreply, assign(socket, :messages, list_messages())}
+  end
+
+  @impl true
+  def handle_info({:message_created, message}, socket) do
+    {:noreply, update(socket, :messages, fn messages -> messages ++ [message] end)}
   end
 
   defp list_messages do


### PR DESCRIPTION
Adiciona métodos de broadcast e subscribe para atualizar todas as sessões conectadas no site com novas as mensagens mais atualizadas.

Fixes #1 

![boom bitch](https://media.giphy.com/media/XKCdA6ERnXp6M/giphy.gif)